### PR TITLE
Fix existing process check.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,6 @@ command = command.join(" ")
 
 # Start MailCatcher
 bash "mailcatcher" do
-    not_if "ps ax | grep -E '#{command}'"
+    not_if "ps ax | grep -E 'mailcatche[r]'"
     code command
 end


### PR DESCRIPTION
The existing code fails as it might return the grep process itself. This
change makes sure it ignore the grep process.
