### PR TITLE
Add make and g++ dependencies for debian/ubuntu

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,6 +10,8 @@ case node['platform_family']
     when "debian"
         package "sqlite"
         package "libsqlite3-dev"
+        package "make"
+        package "g++"
     when "rhel", "fedora", "suse"
         package "libsqlite3-dev"
 end


### PR DESCRIPTION
Installing mailcatcher on Ubuntu (13.10) required installing make and g++.  Added these as dependencies.
