### PR TITLE
Fix incorrect attribute key in php template

### DIFF
--- a/templates/default/mailcatcher.ini.erb
+++ b/templates/default/mailcatcher.ini.erb
@@ -1,1 +1,1 @@
-sendmail_path = <%= node['mailcatcher']['bin'] %> --smtp-port <%= node['mailcatcher']['port'] %>
+sendmail_path = <%= node['mailcatcher']['bin'] %> --smtp-port <%= node['mailcatcher']['smtp-port'] %>


### PR DESCRIPTION
- Change to use `smtp-port` as `port` is not currently defined in
  `defaults.rb` and the documentation lists `smtp-port` as the correct
  key
