### PR TITLE
Changed cookbook name

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             'MailCatcher'
+name             'mailcatcher'
 maintainer       'Bryan te Beek'
 maintainer_email 'bryantebeek@gmail.com'
 license          'Apache 2.0'


### PR DESCRIPTION
Made the cookbook name all lower case. 
This is chef standard and prevents berkshelf from complaining:

Berkshelf::BerksError: Berks command Failed: ... reason: In your Berksfile, you have:

  cookbook 'mailcatcher'

But that cookbook is actually named 'MailCatcher'

This can cause potentially unwanted side-effects in the future.

NOTE: If you do not explicitly set the 'name' attribute in the metadata, the name of the directory will be used instead. This is often a cause of confusion for dependency solving.
