### PR TITLE
One of mailcatcher's dependancies now requires Ruby >= 2.0.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,11 +8,17 @@
 # This is a dependency of MailCatcher
 case node['platform_family']
     when "debian"
+        # remove ruby 1.9
+        %w(ruby ruby-dev).each do |deb|
+            package deb do
+                action :remove
+            end
+        end
         package "sqlite"
         package "libsqlite3-dev"
         package "make"
         package "g++"
-        package "ruby-dev"
+        package "ruby2.0-dev"
     when "rhel", "fedora", "suse"
         package "libsqlite3-dev"
 end


### PR DESCRIPTION
This was causing this recipe to fail.
This forces ruby2 for Debian and Ubuntu but uninstalls Ruby 1.9 which may cause issues for some users.

I'm new to Chef: This works for me but I'm open to suggestions.
